### PR TITLE
Add Html equivalence and test

### DIFF
--- a/src/main/scala/org/scalatestplus/play/Implicits.scala
+++ b/src/main/scala/org/scalatestplus/play/Implicits.scala
@@ -1,0 +1,12 @@
+package org.scalatestplus.play
+
+import org.scalactic.Equivalence
+import play.twirl.api.Html
+
+object Implicits {
+
+  implicit val htmlEquivalence = new Equivalence[Html] {
+    def areEquivalent(a: Html, b: Html): Boolean = a.toString == b.toString
+  }
+
+}

--- a/src/test/scala/org/scalatestplus/play/ImplicitsSpec.scala
+++ b/src/test/scala/org/scalatestplus/play/ImplicitsSpec.scala
@@ -1,0 +1,31 @@
+package org.scalatestplus.play
+
+import Implicits._
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest._
+import play.twirl.api.Html
+
+class ImplicitsSpec extends FunSpec with Matchers with TypeCheckedTripleEquals {
+
+  describe("htmlEquality with triple equals") {
+
+    it("should compile when types are equal"){
+      """Html("hi") === Html("hi")""".stripMargin should compile
+    }
+
+
+    it("should fail to compile when types are unequal"){
+      """Html("hi") === 3""".stripMargin shouldNot compile
+    }
+
+    it("should return false if Htmls contain different strings when built") {
+      Html("hello world") should !==(Html("what"))
+    }
+
+    it("should return true if Htmls contain different strings when built") {
+      Html("hello world") should ===(Html("hello world"))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Since the `Html` class from Play is not a case class, often times you get funny things like 

```scala
Html("hello") shouldBe Html("hello") // fails

Html("hello") shouldNot be(Html("3")) // passes always 
```

I thought it might be helpful to have an `Equivalence[Html]` implicit available in this project so that people can do things like 

```scala
Html("hello") should ===(Html("hello")) // passes

Html("hello") should !==(Html("3")) // passes

Html("hello") should ===("hello") // fails to compile if using TypeCheckedTripleEquals
```