### PR TITLE
Updated the version of play to 2.4.0-RC3, scala version to 2.11.6 and…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs/
 project/project/
 project/target/
 target/
+.idea

--- a/project/ScalaTestPlusPlayBuild.scala
+++ b/project/ScalaTestPlusPlayBuild.scala
@@ -19,7 +19,7 @@ import com.typesafe.sbt.SbtPgp._
 
 object ScalaTestPlusPlayBuild extends Build {
 
-  val releaseVersion = "1.4.0-M1"
+  val releaseVersion = "1.4.0-M2"
   val projectTitle = "ScalaTest + Play" // for scaladoc source urls
 
   def envVar(name: String): Option[String] =
@@ -56,9 +56,9 @@ object ScalaTestPlusPlayBuild extends Build {
 
     version := releaseVersion,
 
-    scalaVersion := "2.11.1",
+    scalaVersion := "2.11.6",
 
-    crossScalaVersions := Seq("2.11.1", "2.10.4"),
+    crossScalaVersions := Seq("2.11.6", "2.10.4"),
 
     resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases",
 
@@ -66,9 +66,9 @@ object ScalaTestPlusPlayBuild extends Build {
 
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.0",
-      "com.typesafe.play" %% "play-test" % "2.4.0-M2",
+      "com.typesafe.play" %% "play-test" % "2.4.0-RC3",
       "org.seleniumhq.selenium" % "selenium-java" % "2.44.0",
-      "com.typesafe.play" %% "play-ws" % "2.4.0-M2"
+      "com.typesafe.play" %% "play-ws" % "2.4.0-RC3"
     ),
 
     parallelExecution in Test := false,

--- a/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
+++ b/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
@@ -15,10 +15,9 @@
  */
 package org.scalatestplus.play
 
-import play.api._
-import libs.ws.WS
-import play.api.mvc.Call
 import play.api.Play.current
+import play.api.libs.ws.{WS, WSRequest}
+import play.api.mvc.Call
 
 /**
  * Trait providing convenience methods to create WS requests in tests.
@@ -36,7 +35,7 @@ trait WsScalaTestClient {
    * @param call the `Call` describing the request
    * @param portNumber the port number of the `TestServer`
    */
-  def wsCall(call: Call)(implicit portNumber: PortNumber): WS.WSRequestHolder = wsUrl(call.url)
+  def wsCall(call: Call)(implicit portNumber: PortNumber): WSRequest = wsUrl(call.url)
 
   /**
    * Construct a WS request for the given relative URL.
@@ -44,5 +43,5 @@ trait WsScalaTestClient {
    * @param url the URL of the request
    * @param portNumber the port number of the `TestServer`
    */
-  def wsUrl(url: String)(implicit portNumber: PortNumber): WS.WSRequestHolder = WS.url("http://localhost:" + portNumber.value + url)
+  def wsUrl(url: String)(implicit portNumber: PortNumber): WSRequest = WS.url("http://localhost:" + portNumber.value + url)
 }


### PR DESCRIPTION
… I have updated WsScalaTestClient so that it no longer relies on WS.WSRequestHolder, which has been removed since 2.4.0-M1.

I have bumped the version number of the project to 1.4.0-M2